### PR TITLE
Add react-snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A "toolkit" is a set of tools in any form that allows you to create applications
 
 * [react-scripts](https://github.com/facebookincubator/create-react-app/tree/master/packages/react-scripts) - This package includes scripts and configuration used by Create React App.
 * [kcd-scripts](https://github.com/kentcdodds/kcd-scripts) - CLI toolbox for common scripts for [Kent C. Dodds](https://github.com/kentcdodds/kcd-scripts)' projects.
+* [react-snap](https://github.com/stereobooster/react-snap) - Zero-configuration framework-agnostic static prerendering for SPAs
 
 ##  Related lists
 


### PR DESCRIPTION
- [x] I have read [Contribution Guidelines](https://github.com/reyronald/awesome-toolkits/blob/master/CONTRIBUTING.md) and followed everything.
- [x] I have an appropriate description with correct grammar.

https://github.com/stereobooster/react-snap

It works out of the box with create-react-app. The idea is that if you are using c-r-a and do not want to eject to do SSR (with Razzle, for example) or do not want to switch to static site generator (to Gatsby, for example) you can use `react-snap` to do prerendering. Improves loading performance and SEO. Also framework agnostic and can work with anything, for example, with Vue